### PR TITLE
(Quick)fixed issue with ghc-8.0.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+# NB: don't set `language: haskell` here
+
+# explicitly request legacy non-sudo based build environment
+sudo: required
+
+# The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
+env:
+ - CABALVER=1.22 GHCVER=7.10.3
+ - CABALVER=1.24 GHCVER=8.0.1
+# - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
+
+# Note: the distinction between `before_install` and `install` is not important.
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks
+
+# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")

--- a/src/Data/TypeLevel/Num/Ops.hs
+++ b/src/Data/TypeLevel/Num/Ops.hs
@@ -385,8 +385,8 @@ infixr 8 ^
 -- Logarithm type-level relation. @LogBase b x e@ establishes that 
 -- @log_base_b x = e@
 --  Note it is not relational (i.e. cannot be used to express exponentiation)
-class (Pos b, b :>=: D2, PosI x, Pos x, Nat e) =>  LogBase b x e  | b x -> e 
-instance  LogBaseF b x e f => LogBase b x e
+class (Pos b, b :>=: D2, Pos x, Nat e) =>  LogBase b x e  | b x -> e 
+instance  (Pos b, b :>=: D2, Pos x, Nat e, LogBaseF b x e f) => LogBase b x e
 
 
 -- | value-level reflection function for LogBase
@@ -398,9 +398,9 @@ logBase = undefined
 -- calculated was exact.
 -- f indicates if the resulting logarithm has no fractional part (i.e.
 -- tells if the result provided is exact)
-class (Pos b, b :>=: D2, PosI x, Pos x, Nat e, Bool f) 
+class (Pos b, b :>=: D2, Pos x, Nat e, Bool f) 
      =>  LogBaseF b x e f | b x -> e f
-instance (Trich x b cmp, LogBaseF' b x e f cmp) => LogBaseF b x e f
+instance (Pos b, b :>=: D2, Pos x, Nat e, Bool f, Trich x b cmp, LogBaseF' b x e f cmp) => LogBaseF b x e f
 
 class (Pos b, b :>=: D2, Pos x, Nat e, Bool f)
      => LogBaseF' b x e f cmp | b x cmp -> e f 
@@ -424,8 +424,8 @@ logBaseF _ _ = (undefined, undefined)
 -- | Assert that a number (@x@) can be expressed as the power of another one
 --   (@b@) (i.e. the fractional part of @log_base_b x = 0@, or, 
 --   in a different way, @exists y . b\^y = x@). 
-class (Pos b, b :>=: D2, PosI x, Pos x) =>  IsPowOf b x
-instance (Trich x b cmp, IsPowOf' b x cmp) => IsPowOf b x
+class (Pos b, b :>=: D2, Pos x) =>  IsPowOf b x
+instance (Pos b, b :>=: D2, Pos x, Trich x b cmp, IsPowOf' b x cmp) => IsPowOf b x
 
 class (Pos b, b :>=: D2, Pos x) => IsPowOf' b x cmp
 -- If lower (x < b), then the logarithm is not exact  

--- a/src/Data/TypeLevel/Num/Ops.hs
+++ b/src/Data/TypeLevel/Num/Ops.hs
@@ -385,7 +385,7 @@ infixr 8 ^
 -- Logarithm type-level relation. @LogBase b x e@ establishes that 
 -- @log_base_b x = e@
 --  Note it is not relational (i.e. cannot be used to express exponentiation)
-class (Pos b, b :>=: D2, Pos x, Nat e) =>  LogBase b x e  | b x -> e 
+class (Pos b, b :>=: D2, PosI x, Pos x, Nat e) =>  LogBase b x e  | b x -> e 
 instance  LogBaseF b x e f => LogBase b x e
 
 
@@ -398,7 +398,7 @@ logBase = undefined
 -- calculated was exact.
 -- f indicates if the resulting logarithm has no fractional part (i.e.
 -- tells if the result provided is exact)
-class (Pos b, b :>=: D2, Pos x, Nat e, Bool f) 
+class (Pos b, b :>=: D2, PosI x, Pos x, Nat e, Bool f) 
      =>  LogBaseF b x e f | b x -> e f
 instance (Trich x b cmp, LogBaseF' b x e f cmp) => LogBaseF b x e f
 
@@ -424,7 +424,7 @@ logBaseF _ _ = (undefined, undefined)
 -- | Assert that a number (@x@) can be expressed as the power of another one
 --   (@b@) (i.e. the fractional part of @log_base_b x = 0@, or, 
 --   in a different way, @exists y . b\^y = x@). 
-class (Pos b, b :>=: D2, Pos x) =>  IsPowOf b x
+class (Pos b, b :>=: D2, PosI x, Pos x) =>  IsPowOf b x
 instance (Trich x b cmp, IsPowOf' b x cmp) => IsPowOf b x
 
 class (Pos b, b :>=: D2, Pos x) => IsPowOf' b x cmp

--- a/src/Data/TypeLevel/Num/Sets.hs
+++ b/src/Data/TypeLevel/Num/Sets.hs
@@ -17,7 +17,7 @@
 -- Positives.
 -- 
 ----------------------------------------------------------------------------
-module Data.TypeLevel.Num.Sets (Pos, PosI, Nat, toNum, toInt, reifyIntegral) where 
+module Data.TypeLevel.Num.Sets (Pos, Nat, toNum, toInt, reifyIntegral) where 
 
 import Data.TypeLevel.Num.Reps
 

--- a/src/Data/TypeLevel/Num/Sets.hs
+++ b/src/Data/TypeLevel/Num/Sets.hs
@@ -17,7 +17,7 @@
 -- Positives.
 -- 
 ----------------------------------------------------------------------------
-module Data.TypeLevel.Num.Sets (Pos, Nat, toNum, toInt, reifyIntegral) where 
+module Data.TypeLevel.Num.Sets (Pos, PosI, Nat, toNum, toInt, reifyIntegral) where 
 
 import Data.TypeLevel.Num.Reps
 

--- a/type-level.cabal
+++ b/type-level.cabal
@@ -35,7 +35,7 @@ description:
  Here is a tutorial on type-level numerals and how to use them to
  implement numerically-parameterized vectors: <http://www.ict.kth.se/forsyde/files/tutorial/tutorial.html#FSVec>
 
-
+cabal-version:  >= 1.6
 category:       Data
 tested-with:    GHC==7.10.1
 extra-source-files: LICENSE,
@@ -57,3 +57,7 @@ Library
   if os(win32)
     -- The symbols for the zillion type level numbers overflows the Windows DLL symbol space.
     cpp-options: -DSLIM
+
+source-repository head
+  type:     git
+  location: https://github.com/forsyde/type-level

--- a/type-level.cabal
+++ b/type-level.cabal
@@ -52,7 +52,7 @@ Library
                    Data.TypeLevel.Num.Sets,
                    Data.TypeLevel.Num.Ops,
                    Data.TypeLevel.Num.Aliases.TH
-  ghc-options:	-Wall
+  ghc-options:	-Wall -Wno-redundant-constraints
   if os(win32)
     -- The symbols for the zillion type level numbers overflows the Windows DLL symbol space.
     cpp-options: -DSLIM

--- a/type-level.cabal
+++ b/type-level.cabal
@@ -1,6 +1,6 @@
 name:           type-level
 version:        0.3.0
-cabal-version:  >= 1.2
+cabal-version:  >= 1.6
 build-type:     Simple
 license:        BSD3
 license-file:   LICENSE
@@ -35,7 +35,6 @@ description:
  Here is a tutorial on type-level numerals and how to use them to
  implement numerically-parameterized vectors: <http://www.ict.kth.se/forsyde/files/tutorial/tutorial.html#FSVec>
 
-cabal-version:  >= 1.6
 category:       Data
 tested-with:    GHC==7.10.1
 extra-source-files: LICENSE,
@@ -60,4 +59,4 @@ Library
 
 source-repository head
   type:     git
-  location: https://github.com/forsyde/type-level
+  location: https://github.com/forsyde/type-level.git


### PR DESCRIPTION
This fix should close #2 needed further on for #1 .

cabal-1.22 does not complain, whereas cabal-1.24 does throw some warnings about redundant constraints. One might look into it. Check [![Build Status](https://travis-ci.org/ugeorge/type-level.svg?branch=master)](https://travis-ci.org/ugeorge/type-level)

@HWoidt : could you please honour this pull request and (eventually) take care of the remaining warnings?

**EDIT** 

In the worst case the warnings can be suppressed by compiling with the `-Wno-redundant-constraints` flag. I do not want to do that since I am not aware of the implementation details.
